### PR TITLE
Bug fix

### DIFF
--- a/src/Actions/Actions.js
+++ b/src/Actions/Actions.js
@@ -86,7 +86,7 @@ export const addFavorite = (movie, user_id) => {
       const movieBody = {
         movie_id: movie.id,
         title: movie.title,
-        poster_path: movie.posterPath,
+        poster_path: movie.poster_path,
         release_date: movie.releaseData,
         vote_average: movie.averageRating,
         overview: movie.overview, 

--- a/src/Components/Card/Card.js
+++ b/src/Components/Card/Card.js
@@ -31,7 +31,7 @@ class Card extends Component {
         {errorRedirect}
         <div className='flipper'>
           <div className='Card front'>
-            <img src={`https://image.tmdb.org/t/p/w500${this.props.movie.posterPath}`} />
+            <img src={`https://image.tmdb.org/t/p/w500${this.props.movie.poster_path}`} />
           </div>
           <div className='Card back'>
             <h1 className='font'>{this.props.movie.title}</h1>

--- a/src/Reducers/Reducers.js
+++ b/src/Reducers/Reducers.js
@@ -19,7 +19,12 @@ export const user = (state = {}, action) => {
         id: action.id
       };
     case 'ADD_USER_FAVORITE' :
-      return {...state, favorites: [...state.favorites, action.movie]};
+      const isDuplicate = state.favorites.find(movie => movie.title === action.movie.title);
+      if(!isDuplicate) {
+        return {...state, favorites: [...state.favorites, action.movie]};
+      } else {
+        return state
+      }
     case 'REMOVE_USER_FAVORITE' :
       newState = {...state, favorites: state.favorites.filter(currentMovie => currentMovie.movie_id !== action.movie_id)};
       return newState;

--- a/src/apiCalls/helper.js
+++ b/src/apiCalls/helper.js
@@ -4,7 +4,7 @@ export const cleanData = (data) => {
       id: film.id,
       title: film.original_title,
       averageRating: film.vote_average,
-      posterPath: film.poster_path,
+      poster_path: film.poster_path,
       releaseData: film.release_date,
       overview: film.overview
     };


### PR DESCRIPTION
Fixed: Favorite cards render during current session and  duplicate favorites do not render.

Still needs to be fixed: 
- Remove duplicates from server storage
- Remove favorited card during current session (looks like the user_id is not available to the removeFavorite thunk method during the current session -- only on a refresh)